### PR TITLE
Support *new* package compression format

### DIFF
--- a/nginx.template
+++ b/nginx.template
@@ -36,7 +36,7 @@ http {
 
         # Requests for actual packages should be served directly from cache if available.
         #   If not available, retrieve and save the package from an upstream mirror.
-        location ~ \.tar\.xz$ {
+        location ~ \.tar\.zst$ {
             try_files $uri @pkg_mirror;
         }
 

--- a/nginx.template
+++ b/nginx.template
@@ -36,7 +36,7 @@ http {
 
         # Requests for actual packages should be served directly from cache if available.
         #   If not available, retrieve and save the package from an upstream mirror.
-        location ~ \.tar\.zst$ {
+        location ~ \.tar\.(zst|xz)$ {
             try_files $uri @pkg_mirror;
         }
 


### PR DESCRIPTION
In 2020, archlinux [officialy](https://archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/) changed their compression scheme from `tar.xz` to `tar.zst`.

The current nginx configuration only support package with the `tar.xz` extension and answer with a 404 error code for package in the *new* format.

This pull request fix this issue will still being backward compatible (no idea if there is a use case...)